### PR TITLE
use X-Forwarded-Proto header for protocol detection

### DIFF
--- a/lib/google-oauth.js
+++ b/lib/google-oauth.js
@@ -49,7 +49,7 @@ exports.configureOAuth = function(express, app, config) {
   var lazySetupPassport = function(req) {
     passportIsSet = true;
 
-    var protocol = req.connection.encrypted ? "https" : "http";
+    var protocol = (req.connection.encrypted || req.headers['x-forwarded-proto'] == "https" ) ? "https" : "http";
 
   //not doing anything with this:
   //it will try to serialize the users in the session.


### PR DESCRIPTION
if kibana-proxy runs behind reverse proxy (e.g. Amazon ELB or Apache + Passenger), always set redirect url with "http://".
this patch fixes this problem, use "X-Forwarded-Proto" header for detection.
